### PR TITLE
新增助手管理功能，同时在相关页面中集成

### DIFF
--- a/src/components/RouteList/index.tsx
+++ b/src/components/RouteList/index.tsx
@@ -27,6 +27,7 @@ import Decycle from "@/pages/Decycle";
 import Record from "@/pages/Record";
 import Oss from "@/pages/Oss";
 import Album from "@/pages/Album";
+import Assistant from "@/pages/Assistant";
 
 import PageTitle from "../PageTitle";
 
@@ -67,6 +68,7 @@ export default () => {
         { path: "/file", title: "文件管理", component: <File /> },
         { path: "/iter", title: "项目更新记录", component: <Iterative /> },
         { path: "/work", title: "工作台", component: <Work /> },
+        { path: "/assistant", title: "助手管理", component: <Assistant /> },
     ];
 
     const [routes, setRoutes] = useState<typeof routesAll | null>(null);

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -156,6 +156,11 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
               name: "文章管理"
             },
             {
+              to: "/assistant",
+              path: "assistant",
+              name: "助手管理"
+            },
+            {
               to: "/record",
               path: "record",
               name: "说说管理"

--- a/src/hooks/useAssistant.tsx
+++ b/src/hooks/useAssistant.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { message } from 'antd';
+import { 
+  getAssistants, 
+  saveAssistants, 
+  testAssistantConnection,
+  callAssistantAPI
+} from '@/services/assistant';
+import { Assistant } from '@/types/app/assistant';
+
+export default function useAssistant() {
+  const [assistants, setAssistants] = useState<Assistant[]>([]);
+  const [selectedAssistant, setSelectedAssistant] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [testing, setTesting] = useState(false);
+
+  // 初始化加载助手列表
+  useEffect(() => {
+    const loadedAssistants = getAssistants();
+    setAssistants(loadedAssistants);
+    
+    // 设置默认助手
+    const defaultAssistant = loadedAssistants.find(a => a.isDefault);
+    if (defaultAssistant) {
+      setSelectedAssistant(defaultAssistant.id);
+    }
+  }, []);
+
+  // 添加或更新助手
+  const saveAssistant = (assistant: Omit<Assistant, 'id' | 'isDefault'>, id?: string) => {
+    setLoading(true);
+    try {
+      let updatedAssistants: Assistant[];
+      
+      if (id) {
+        // 更新现有助手
+        updatedAssistants = assistants.map(a => 
+          a.id === id ? { ...assistant, id, isDefault: a.isDefault } : a
+        );
+      } else {
+        // 添加新助手
+        const newAssistant = {
+          ...assistant,
+          id: Date.now().toString(),
+          isDefault: assistants.length === 0
+        };
+        updatedAssistants = [...assistants, newAssistant];
+      }
+
+      saveAssistants(updatedAssistants);
+      setAssistants(updatedAssistants);
+      message.success(id ? '助手已更新' : '助手已添加');
+      return true;
+    } catch (error) {
+      message.error('保存失败');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 删除助手
+  const deleteAssistant = (id: string) => {
+    const updatedAssistants = assistants.filter(a => a.id !== id);
+    saveAssistants(updatedAssistants);
+    setAssistants(updatedAssistants);
+    
+    // 如果删除的是当前选中的助手，清空选中状态
+    if (selectedAssistant === id) {
+      setSelectedAssistant(null);
+    }
+    
+    message.success('助手已删除');
+  };
+
+  // 设置默认助手
+  const setDefaultAssistant = (id: string) => {
+    const updated = assistants.map(a => ({
+      ...a,
+      isDefault: a.id === id
+    }));
+    saveAssistants(updated);
+    setAssistants(updated);
+    setSelectedAssistant(id);
+    message.success('默认助手已更新');
+  };
+
+  // 测试助手连接
+  const testConnection = async (assistant: Assistant) => {
+    setTesting(true);
+    const result = await testAssistantConnection(assistant);
+    setTesting(false);
+    return result;
+  };
+
+  // 调用助手API
+  const callAssistant = async (
+    messages: Array<{role: string; content: string}>,
+    options?: {
+      stream?: boolean;
+      temperature?: number;
+      max_tokens?: number;
+    }
+  ) => {
+    if (!selectedAssistant) {
+      message.error('请先选择助手');
+      return null;
+    }
+
+    const assistant = assistants.find(a => a.id === selectedAssistant);
+    if (!assistant) {
+      message.error('助手不存在');
+      return null;
+    }
+
+    return callAssistantAPI(assistant, messages, options);
+  };
+
+  return {
+    assistants,
+    selectedAssistant,
+    setSelectedAssistant,
+    loading,
+    testing,
+    saveAssistant,
+    deleteAssistant,
+    setDefaultAssistant,
+    testConnection,
+    callAssistant
+  };
+}

--- a/src/pages/Assistant/index.tsx
+++ b/src/pages/Assistant/index.tsx
@@ -1,0 +1,135 @@
+import { Button, Card, Form, Input, List, Modal } from 'antd';
+import { useState } from 'react';
+import { PlusOutlined } from '@ant-design/icons';
+import Title from '@/components/Title';
+import useAssistant from '@/hooks/useAssistant';
+
+export default () => {
+  const [form] = Form.useForm();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  
+  const {
+    assistants,
+    testing,
+    saveAssistant,
+    deleteAssistant,
+    setDefaultAssistant,
+    testConnection
+  } = useAssistant();
+
+  // 提交表单
+  const handleSubmit = () => {
+    form.validateFields().then(values => {
+      const success = saveAssistant(values, editingId || undefined);
+      if (success) {
+        setIsModalOpen(false);
+        form.resetFields();
+        setEditingId(null);
+      }
+    });
+  };
+
+  return (
+    <div>
+      <Title value="助手管理">
+        <Button 
+          type="primary" 
+          icon={<PlusOutlined />}
+          onClick={() => setIsModalOpen(true)}
+        >
+          添加助手
+        </Button>
+      </Title>
+
+      <Card>
+        <List
+          dataSource={assistants}
+          renderItem={(item) => (
+            <List.Item
+              actions={[
+                <Button type="link" onClick={() => {
+                  form.setFieldsValue(item);
+                  setEditingId(item.id);
+                  setIsModalOpen(true);
+                }}>
+                  编辑
+                </Button>,
+                <Button 
+                  type="link" 
+                  onClick={() => testConnection(item)}
+                  loading={testing}
+                >
+                  测试连接
+                </Button>,
+                <Button 
+                  type={item.isDefault ? 'primary' : 'default'} 
+                  onClick={() => setDefaultAssistant(item.id)}
+                >
+                  {item.isDefault ? '默认助手' : '设为默认'}
+                </Button>,
+                <Button 
+                  type="link" 
+                  danger 
+                  onClick={() => deleteAssistant(item.id)}
+                >
+                  删除
+                </Button>
+              ]}
+            >
+              <List.Item.Meta
+                title={item.name}
+                description={`${item.baseUrl} (模型: ${item.modelId})`}
+              />
+            </List.Item>
+          )}
+        />
+      </Card>
+
+      <Modal
+        title={editingId ? '编辑助手' : '添加助手'}
+        open={isModalOpen}
+        onOk={handleSubmit}
+        onCancel={() => {
+          setIsModalOpen(false);
+          form.resetFields();
+          setEditingId(null);
+        }}
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="name"
+            label="助手名称"
+            rules={[{ required: true, message: '请输入助手名称' }]}
+          >
+            <Input placeholder="例如: DeepSeek" />
+          </Form.Item>
+
+          <Form.Item
+            name="baseUrl"
+            label="API基础地址"
+            rules={[{ required: true, message: '请输入API基础地址' }]}
+          >
+            <Input placeholder="例如: https://api.deepseek.com" />
+          </Form.Item>
+
+          <Form.Item
+            name="apiKey"
+            label="API密钥"
+            rules={[{ required: true, message: '请输入API密钥' }]}
+          >
+            <Input.Password placeholder="输入API密钥" />
+          </Form.Item>
+
+          <Form.Item
+            name="modelId"
+            label="模型ID"
+            rules={[{ required: true, message: '请输入模型ID' }]}
+          >
+            <Input placeholder="例如: deepseek-chat" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};

--- a/src/pages/Role/index.tsx
+++ b/src/pages/Role/index.tsx
@@ -274,7 +274,8 @@ export default () => {
         "swiper": "轮播图管理",
         "tag": "标签管理",
         "wall": "留言管理",
-        "permission": "权限管理"
+        "permission": "权限管理",
+        "assistant": "助手管理",
     };
 
     // 让n改变 触发Transfer重新渲染

--- a/src/services/assistant.ts
+++ b/src/services/assistant.ts
@@ -1,0 +1,109 @@
+import { message } from 'antd';
+import { Assistant } from '@/types/app/assistant';
+
+const ASSISTANT_STORAGE_KEY = 'assistants';
+
+// 从本地存储获取助手列表
+export const getAssistants = (): Assistant[] => {
+  const saved = localStorage.getItem(ASSISTANT_STORAGE_KEY);
+  return saved ? JSON.parse(saved) : [];
+};
+
+// 保存助手列表到本地存储
+export const saveAssistants = (assistants: Assistant[]) => {
+  localStorage.setItem(ASSISTANT_STORAGE_KEY, JSON.stringify(assistants));
+};
+
+// 测试助手连接
+export const testAssistantConnection = async (assistant: Assistant) => {
+  try {
+    // 确保baseURL以/v1结尾
+    const baseUrl = assistant.baseUrl.endsWith('/v1') 
+      ? assistant.baseUrl 
+      : `${assistant.baseUrl.replace(/\/+$/, '')}/v1`;
+    
+    // 确保API密钥没有多余空格
+    const apiKey = assistant.apiKey.trim();
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip, deflate, br'
+      },
+      body: JSON.stringify({
+        model: assistant.modelId || 'moonshot-v1-8k',
+        messages: [
+          { 
+            role: 'system', 
+            content: '你是 Kimi，由 Moonshot AI 提供的人工智能助手，你更擅长中文和英文的对话。你会为用户提供安全，有帮助，准确的回答。'
+          },
+          { role: 'user', content: '测试连接' }
+        ],
+        temperature: 0.3
+      })
+    });
+
+    if (response.ok) {
+      message.success('连接测试成功');
+      return true;
+    } else {
+      message.error('连接测试失败');
+      return false;
+    }
+  } catch (error) {
+    message.error('连接测试失败');
+    return false;
+  }
+};
+
+// 调用助手API
+export const callAssistantAPI = async (
+  assistant: Assistant,
+  messages: Array<{role: string; content: string}>,
+  options: {
+    stream?: boolean;
+    temperature?: number;
+    max_tokens?: number;
+  } = {}
+) => {
+  try {
+    // 确保baseURL以/v1结尾
+    const baseUrl = assistant.baseUrl.endsWith('/v1') 
+      ? assistant.baseUrl 
+      : `${assistant.baseUrl.replace(/\/+$/, '')}/v1`;
+    
+    // 确保API密钥没有多余空格
+    const apiKey = assistant.apiKey.trim();
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip, deflate, br'
+      },
+      body: JSON.stringify({
+        model: assistant.modelId || 'moonshot-v1-8k',
+        messages,
+        stream: options.stream ?? false,
+        temperature: options.temperature ?? 0.3,
+        max_tokens: options.max_tokens,
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`API request failed with status ${response.status}`);
+    }
+
+    if (options.stream) {
+      return response.body?.getReader();
+    }
+    
+    return await response.json();
+  } catch (error) {
+    message.error('调用助手API失败');
+    throw error;
+  }
+};

--- a/src/types/app/assistant.d.ts
+++ b/src/types/app/assistant.d.ts
@@ -1,0 +1,8 @@
+export interface Assistant {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+  isDefault: boolean;
+}


### PR DESCRIPTION
### 变更内容
- 新增助手管理页面 (`/assistant`)
- 添加 `useAssistant` hook 用于管理助手状态
- 实现助手服务 (`services/assistant.ts`) 包含:
  - 本地存储管理助手配置
  - 助手连接测试功能
  - API 调用实现
- 在创作页面集成助手功能:
  - 续写、优化、一键生成等 AI 功能现在通过配置的助手实现
  - 原有 AI 功能已迁移到新助手系统

### 使用说明
1. 在助手管理页面添加助手配置 (API地址、密钥等)
2. 测试连接确保配置正确
3. 在创作页面即可使用助手功能

### 部分截图
1. 助手管理页面
![image](https://github.com/user-attachments/assets/b70ff923-5bb1-4bf4-a19a-22d8c20571a3)
2. 创作页面
![image](https://github.com/user-attachments/assets/022f5aec-12b7-4510-ba8a-702fe7d09110)
3. 发布页面
![image](https://github.com/user-attachments/assets/8e2c3262-da73-4ebf-9df3-873937256bbf)


### 注意事项
- 只经过了 Kimi 的 api 测试，其他模型提供商的 baseurl 可能不一样