### PR TITLE
fix(setup): 修改个人信息时 user store 字段丢失导致后续操作失败

### DIFF
--- a/src/pages/setup/system/components/My/index.tsx
+++ b/src/pages/setup/system/components/My/index.tsx
@@ -28,9 +28,11 @@ export default () => {
       setLoading(true);
       await editUserDataAPI({ ...values, id: user.id });
       message.success('🎉 修改用户信息成功');
-      setUser(values as User);
+      // 合并而非覆盖，保留 id/username 等原有字段，避免后续依赖这些字段的操作失败
+      setUser({ ...user, ...values });
     } catch (error) {
       console.error(error);
+    } finally {
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Bug 描述

在「系统设置 → 个人配置」页面修改昵称后，user store 中的 `id`、`username` 等字段会被表单值整个覆盖丢失，导致后续依赖这些字段的操作失败（如账号配置页无法修改密码）。

## 复现步骤

1. 登录后台，进入「系统设置 → 个人配置」
2. 修改昵称并点击「确定」（第一次会成功）
3. 进入「系统设置 → 账号配置」尝试修改密码
4. **预期**：可以正常修改密码
5. **实际**：账号输入框为空，提交后后端报「用户名不能为空」

## 根因

```typescript
// 修改前
const onSubmit = async (values: UserForm) => {
  try {
    setLoading(true);
    await editUserDataAPI({ ...values, id: user.id });
    message.success('🎉 修改用户信息成功');
    setUser(values as User);   // ← values 仅含 {name, email, avatar, info}
  } catch (error) {
    console.error(error);
    setLoading(false);
  }
};
```

表单 `values` 只有 4 个字段，但 `setUser(values as User)` 直接整个覆盖了 store 中的 user 对象，丢失了 `id`、`username` 等关键字段。由于 user store 使用了 `persist` 中间件，破坏后的数据会被写入 localStorage，引发连锁故障：

```
修改昵称 → setUser(values) 丢字段
  → localStorage 中的 user 被 {name,email,avatar,info} 覆盖
  → System 页面挂载时从 localStorage 恢复 → user.username 为 undefined
  → initialValues.newUsername = '' → 账号输入框空
  → handleSubmit 发送 oldUsername: '' → 后端校验失败 → 无法修改密码
```

## 修复

改为合并而非覆盖，保留原有字段：

```typescript
// 修改后
const onSubmit = async (values: UserForm) => {
  try {
    setLoading(true);
    await editUserDataAPI({ ...values, id: user.id });
    message.success('🎉 修改用户信息成功');
    setUser({ ...user, ...values });   // 合并更新，保留 id/username
  } catch (error) {
    console.error(error);
  } finally {
    setLoading(false);   // 顺带修复：成功路径下按钮永久 loading 的问题
  }
};
```

顺带修复：原代码 `setLoading(false)` 仅在 catch 中执行，成功路径下按钮会永久处于 loading 状态。改为 `finally` 块统一释放。

## 影响范围

- 仅修改 1 个函数，不影响任何现有功能
- 修复后 `id`、`username` 等字段得以保留，后续依赖这些字段的操作（如修改密码）恢复正常

## 测试

- [x] 修改昵称后立即修改密码 → 正常
- [x] 修改昵称后刷新页面 → user 信息完整（id、username 仍在）
- [x] 修改其他字段（邮箱/头像/简介）→ 正常
- [x] 提交成功后按钮 loading 状态正常释放
- [x] 提交失败时按钮 loading 状态正常释放
